### PR TITLE
ci: harden changelog automation follow-up

### DIFF
--- a/.github/workflows/changelog-automation.yml
+++ b/.github/workflows/changelog-automation.yml
@@ -12,25 +12,49 @@ permissions:
 
 jobs:
   update-changelog:
-    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
+      - name: Skip automation loops for bot pushes
+        if: github.actor == 'github-actions[bot]'
+        run: echo "Triggered by github-actions[bot]; skipping changelog automation."
+
       - name: Checkout
+        if: github.actor != 'github-actions[bot]'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Update changelog
+        if: github.actor != 'github-actions[bot]'
         run: ./scripts/update-changelog.sh
 
+      - name: Detect workflow PR permission policy
+        if: github.actor != 'github-actions[bot]'
+        id: pr-policy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          response=$(curl -sS \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/permissions/workflow")
+
+          if [[ "$(printf '%s' "${response}" | jq -r '.can_approve_pull_request_reviews')" == "true" ]]; then
+            echo "can_open_pr=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "can_open_pr=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Open changelog pull request
+        if: github.actor != 'github-actions[bot]' && steps.pr-policy.outputs.can_open_pr == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: cx/changelog-auto-${{ github.run_id }}
           base: main
-          commit-message: chore: update changelog
-          title: chore: update changelog
+          commit-message: "chore: update changelog"
+          title: "chore: update changelog"
           body: |
             Automated changelog refresh after a `main` update.
           labels: |
@@ -39,3 +63,7 @@ jobs:
           delete-branch: true
           add-paths: |
             CHANGELOG.md
+
+      - name: Skip PR creation when repository policy blocks actions PRs
+        if: github.actor != 'github-actions[bot]' && steps.pr-policy.outputs.can_open_pr != 'true'
+        run: echo "Repository policy blocks Actions-created PRs; changelog PR creation skipped."

--- a/docs/audits/public-logic-audit-2026-02-22.md
+++ b/docs/audits/public-logic-audit-2026-02-22.md
@@ -32,14 +32,16 @@
 | `./scripts/accessibility-check.sh` | PASS | Accessibility baseline passed |
 | `node dist/app/cli.js --help` | PASS | Public CLI help output rendered correctly |
 | `npm audit --audit-level=high` | PASS | No high/critical vulnerabilities detected |
+| Changelog automation workflow hardening | PASS | Added bot-safe step-level skip and policy-aware PR creation fallback to avoid automation failures |
 
 ## Findings Register
 | Severity | Area | Repro | Status | Fix |
 |---|---|---|---|---|
 | None | Public logic | N/A | Closed | No regressions found in audited surfaces |
+| P1 | Workflow reliability | Changelog automation run failed with zero jobs on push events due invalid unquoted YAML scalars in `commit-message`/`title` | Fixed | Quoted YAML scalars, moved bot guard to step-level skip, and added policy-aware PR creation fallback in `.github/workflows/changelog-automation.yml` |
 
 ## Residual Risks / Follow-ups
-- Non-primary automation workflows may fail independently of public runtime logic and should be monitored separately.
+- Changelog automation should be monitored after next push to confirm the policy-aware fallback path behaves as expected under current Actions policy.
 
 ## Attestation
 - This wave is maintenance and hardening only.


### PR DESCRIPTION
## Summary
- fix changelog automation workflow compile failure by quoting YAML scalar values with `:`
- harden bot-trigger handling to avoid no-job failures
- add policy-aware fallback to skip PR creation when repository Actions policy blocks it
- document follow-up findings in audit artifact

## Validation
- YAML parse validation for `.github/workflows/changelog-automation.yml` passed
- existing audit findings updated in `docs/audits/public-logic-audit-2026-02-22.md`

## No New Feature Attestation
- Maintenance-only workflow reliability hardening.
